### PR TITLE
Add relative css declaration to div for resizing.

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -131,7 +131,11 @@ var ItemMeasurer = /*#__PURE__*/function (_Component) {
         height: _this.props.size + expandScrollDelta + "px",
         width: '100%'
       };
-      var renderItem = /*#__PURE__*/React__default.createElement("div", null, item, /*#__PURE__*/React__default.createElement("div", {
+      var renderItem = /*#__PURE__*/React__default.createElement("div", {
+        style: {
+          position: 'relative'
+        }
+      }, item, /*#__PURE__*/React__default.createElement("div", {
         style: scrollableContainerStyles
       }, /*#__PURE__*/React__default.createElement("div", {
         dir: "ltr",

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -124,7 +124,11 @@ var ItemMeasurer = /*#__PURE__*/function (_Component) {
         height: _this.props.size + expandScrollDelta + "px",
         width: '100%'
       };
-      var renderItem = /*#__PURE__*/React.createElement("div", null, item, /*#__PURE__*/React.createElement("div", {
+      var renderItem = /*#__PURE__*/React.createElement("div", {
+        style: {
+          position: 'relative'
+        }
+      }, item, /*#__PURE__*/React.createElement("div", {
         style: scrollableContainerStyles
       }, /*#__PURE__*/React.createElement("div", {
         dir: "ltr",

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -149,7 +149,7 @@ export default class ItemMeasurer extends Component {
     };
 
     const renderItem = (
-      <div>
+      <div style={{ position: 'relative' }}>
         {item}
         <div style={scrollableContainerStyles}>
           <div dir="ltr" style={scrollableWrapperStyle}>


### PR DESCRIPTION
#### Summary
 * On change of heights of items onScroll is triggered which is used for keeping the scroll position at the bottom

 * Since the relative property is removed the absolute positioned the element does not trigger onScroll creating the issue of not correcting the scroll position. It used to exist here at https://github.com/mattermost/react-window/blob/feature/reverseScroll/src/ItemMeasurer.js#L196. While refactoring I thought it isn't needed anymore. 

For the logic of how we detect change in heights of posts, refer
    //Heavily inspired from https://github.com/marcj/css-element-queries/blob/master/src/ResizeSensor.js
    //and https://github.com/wnr/element-resize-detector/blob/master/src/detection-strategy/scroll.js
    //For more info http://www.backalleycoder.com/2013/03/18/cross-browser-event-based-element-resize-detection/#comment-244

A possible improvement here is to change this code to resize observer now that it has decent support(We might have to bump edge min version and also check for firefox issues with the API)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26063
