### PR TITLE
rename package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-window",
+  "name": "dynamic-virtualized-list",
   "version": "1.0.0-beta",
   "description": "Dynamic virtualized list",
   "author": "Sudheer Timmaraju <sudheer.105@gmail.com> (https://github.com/sudheerDev/)",


### PR DESCRIPTION
Referred to as package `dynamic-virtualized-list` ([here](https://github.com/mattermost/mattermost-webapp/blob/master/package.json#L19)), renaming to sync and for package-lock/`npm update` consistency. 

(Related: https://github.com/mattermost/mattermost-webapp/pull/5901)

